### PR TITLE
Add versy-docs.rweb.site

### DIFF
--- a/records.json
+++ b/records.json
@@ -73,6 +73,7 @@
     "uefndev": "devuefn.vercel.app",
     "uefndevkit": "uefndevkit.vercel.app",
     "vecctr": "vecctr.vercel.app",
+    "versy-docs": "clynbmilio.github.io",
     "weblog": "weblogbd.vercel.app",
     "whoshub": "frdze.github.io",
     "www": "katorlys.github.io/rweb.site",


### PR DESCRIPTION
### Website

**Link:** https://wewwwwww.netlify.app/

**Screenshot:**

![Immich API Reference preview](https://raw.githubusercontent.com/clynbmilio/immich-sourcey-docs/main/assets/preview.png)

### Description

`versy-docs.rweb.site` will host an independent, community-generated API reference for the real open-source Immich project. The site is built with Sourcey 3.6.3 from Immich's official OpenAPI specification at commit `b24a61714220a0c3999f4c24419b71472ee070c5` and documents 254 endpoints plus 373 schemas.

The source, exact commit, adapter, checksums, and complete page list are public at https://wewwwwww.netlify.app/evidence.json and https://github.com/clynbmilio/immich-sourcey-docs. The custom domain is already configured in that GitHub Pages repository through its `CNAME` file.

### Checklist

- [x] I have starred the repository.
- [x] I have read and accepted the [Terms of Service](https://github.com/katorlys/rweb.site/blob/main/Terms-of-Service.md).
- [x] There is reasonable content on my site.
- [x] I have configured a custom domain for my site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new hostname mapping to support additional service endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->