### PR TITLE
Add bw subdomain

### DIFF
--- a/records.json
+++ b/records.json
@@ -13,6 +13,7 @@
     "assets": "assetsportal.blogspot.com",
     "aurorabot": "aurora-7qp.pages.dev",
     "avalonia": "202420505.github.io/avalonia-docs-ko",
+    "bw": "fd34840a-ab67-4ee4-9ecd-efbfa7e96f8e.cfargotunnel.com",
     "bytecord": "bytecordweb.vercel.app",
     "chowdhurymuhtadeemaheer": "sites.google.com/view/chowdhurymuhtadeemaheer",
     "codersplanet": "codersplanet.vercel.app",

--- a/records.json
+++ b/records.json
@@ -13,7 +13,7 @@
     "assets": "assetsportal.blogspot.com",
     "aurorabot": "aurora-7qp.pages.dev",
     "avalonia": "202420505.github.io/avalonia-docs-ko",
-    "bw": "fd34840a-ab67-4ee4-9ecd-efbfa7e96f8e.cfargotunnel.com",
+    "bw": "4d19ee7a-67ae-4ace-861b-b899438b52e1.cfargotunnel.com",
     "bytecord": "bytecordweb.vercel.app",
     "chowdhurymuhtadeemaheer": "sites.google.com/view/chowdhurymuhtadeemaheer",
     "codersplanet": "codersplanet.vercel.app",

--- a/records.json
+++ b/records.json
@@ -13,7 +13,7 @@
     "assets": "assetsportal.blogspot.com",
     "aurorabot": "aurora-7qp.pages.dev",
     "avalonia": "202420505.github.io/avalonia-docs-ko",
-    "bw": "4d19ee7a-67ae-4ace-861b-b899438b52e1.cfargotunnel.com",
+    "bw": "fd34840a-ab67-4ee4-9ecd-efbfa7e96f8e.cfargotunnel.com",
     "bytecord": "bytecordweb.vercel.app",
     "chowdhurymuhtadeemaheer": "sites.google.com/view/chowdhurymuhtadeemaheer",
     "codersplanet": "codersplanet.vercel.app",


### PR DESCRIPTION
## Website

Link: https://bwshebeihourssign.cc.cd

The site is currently live at https://bwshebeihourssign.cc.cd (an attendance signing system). Once this PR is merged and the CNAME for w is added, the site will be accessible at https://bw.rweb.site.

Screenshot: The website is an attendance sign-in system with a clean UI showing employee check-in records.

## Checklist

- [x] I have starred the repository.
- [x] I have read and accepted the [Terms of Service](https://github.com/katorlys/rweb.site/blob/main/Terms-of-Service.md).
- [x] There is reasonable content on my site.
- [x] I have configured a custom domain for my site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS routing for the `bw` hostname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->