### PR TITLE
Add scantracker.rweb.site

### DIFF
--- a/records.json
+++ b/records.json
@@ -65,6 +65,7 @@
     "rosaldivo": "z-headscale.duckdns.org",
     "ruclub": "ruclub.vercel.app",
     "rucsu": "roktim526.github.io/raksu",
+    "scantracker": "jebsapple.github.io",
     "shaurya": "defsnip.vercel.app",
     "snowycloudservers": "jf4yo2dy.up.railway.app",
     "softwares": "softwares-hub.vercel.app",


### PR DESCRIPTION
Add CNAME for scantracker.rweb.site → jebsapple.github.io

Scanlation team tracker web app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `scantracker` site mapping, enabling it to resolve through the configured domain records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->