### PR TITLE
Add news-portfolio subdomain

### DIFF
--- a/records.json
+++ b/records.json
@@ -48,6 +48,7 @@
     "maxvel187": "alternativeendpointdomains.vercel.app",
     "moji-kakushi": "2ndnuts.github.io",
     "mwth": "blogsmwth.vercel.app",
+    "news-portfolio": "news-portfolio-eight.vercel.app",
     "nexora": "oshekharo.github.io",
     "obp": "obp.miniblacktw.myds.me",
     "onbuch": "onbuch.vercel.app",


### PR DESCRIPTION
Registers the new news-portfolio.rweb.site subdomain CNAME mapping to news-portfolio-eight.vercel.app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing support for the `news-portfolio` site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->