### PR TITLE
Add DNS record for alexmwendwa.rweb.site

### DIFF
--- a/records.json
+++ b/records.json
@@ -1,4 +1,9 @@
 {
+  "alexmwendwa": {
+  "target": "cname.vercel-dns.com",
+  "type": "CNAME",
+  "ttl": 3600
+}
   "cname": {
     "1dst": "1d10t1c-stud10s.github.io",
     "7ames": "7ames-website.pages.dev",

--- a/records.json
+++ b/records.json
@@ -1,6 +1,6 @@
 {
-  "alexmwendwa": {
-  "target": "cname.vercel-dns.com",
+"alexmwendwa": {
+  "target": "my-portfolio-frontend-alex113.vercel.app",
   "type": "CNAME",
   "ttl": 3600
 }

--- a/records.json
+++ b/records.json
@@ -1,15 +1,11 @@
 {
-"alexmwendwa": {
-  "target": "my-portfolio-frontend-alex113.vercel.app",
-  "type": "CNAME",
-  "ttl": 3600
-}
   "cname": {
     "1dst": "1d10t1c-stud10s.github.io",
     "7ames": "7ames-website.pages.dev",
     "aashish-anil": "ashphotfolio.vercel.app",
     "admin-devuefn": "admin-devuefn.vercel.app",
     "ajabat": "ajabat.pages.dev",
+    "alexmwendwa": "my-portfolio-frontend-alex113.vercel.app",
     "alittlebirdietoldme": "alessiadigennaro-arch.github.io",
     "ancxx": "anci4nttt.vercel.app",
     "arindhimar": "arin-portfolio-git-main-alvfcoc-gmailcoms-projects.vercel.app",


### PR DESCRIPTION
Please add a CNAME record for alexmwendwa.rweb.site pointing to my Vercel portfolio.

**Site URL:** https://my-portfolio-frontend-alex113.vercel.app

**Subdomain:** alexmwendwa.rweb.site

**Target:** cname.vercel-dns.com

**Type:** CNAME

**TTL:** 3600

This is my personal developer portfolio. Thank you!
<img width="1416" height="793" alt="Screenshot 2026-07-22 at 04 23 04" src="https://github.com/user-attachments/assets/c6f50486-9e8e-42cb-a2aa-dff251de7d32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added DNS CNAME hosting configuration for the `alexmwendwa` domain, pointing it to the designated frontend host (`my-portfolio-frontend-alex113.vercel.app`) so the domain resolves correctly to the latest site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="468" height="44" alt="image" src="https://github.com/user-attachments/assets/8f79d78d-d653-482a-9bec-896a4b083452" />

<img width="451" height="161" alt="image" src="https://github.com/user-attachments/assets/11877954-c8c0-4ddf-ba0e-bec73fb23a4e" />
