### PR TITLE
Add crux subdomain

### DIFF
--- a/records.json
+++ b/records.json
@@ -20,6 +20,7 @@
     "codersplanet": "codersplanet.vercel.app",
     "colin": "proxy.col1n.fr",
     "cracked": "hxncvxz.github.io",
+    "crux": "emran-goat.github.io",
     "dashboard-devuefn": "dashboard-devuefn.vercel.app",
     "ddinghub": "chococharcoal.github.io",
     "devlog": "rblog-bd.vercel.app",


### PR DESCRIPTION
Requesting the crux.rweb.site subdomain for the CRUX project site hosted on GitHub Pages at emran-goat.github.io. Context: https://github.com/Emran-goat/crux-site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `crux` domain mapping for the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->