### PR TITLE
Add better-epub.rweb.site

### DIFF
--- a/records.json
+++ b/records.json
@@ -14,6 +14,7 @@
     "aserver": "aserver.vrtxx.uk",
     "assets": "assetsportal.blogspot.com",
     "aurorabot": "aurora-7qp.pages.dev",
+    "better-epub": "pablodcruz.github.io",
     "bytecord": "bytecordweb.vercel.app",
     "channel101": "channel101.github.io",
     "chowdhurymuhtadeemaheer": "ghs.googlehosted.com",


### PR DESCRIPTION
Registers `better-epub.rweb.site` for Better ePub, a secure, accessible, local-first EPUB 2/3 reader.

- Project: https://github.com/pablodcruz/better-epub
- Live GitHub Pages deployment: https://pablodcruz.github.io/better-epub/
- DNS target: `pablodcruz.github.io`
- The custom domain is already configured in the repository's GitHub Pages settings.

The change adds one alphabetically ordered CNAME record and `records.json` has been validated as JSON.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `better-epub` custom domain mapping for the hosted site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->