### PR TITLE
Add mhacdelivery rweb.site subdomain

### DIFF
--- a/records.json
+++ b/records.json
@@ -60,6 +60,7 @@
     "luxhost": "luxstories.github.io",
     "lyhoangkhang": "lyhoangkhang.vercel.app",
     "maxvel187": "alternativeendpointdomains.vercel.app",
+    "mhacdelivery": "mhacdeliverypaniqui112021-ops.github.io",
     "moji-kakushi": "2ndnuts.github.io",
     "mwth": "blogsmwth.vercel.app",
     "nallaneram": "nallaneram-web.vercel.app",
@@ -109,7 +110,6 @@
     "whoshub": "frdze.github.io",
     "www": "katorlys.github.io",
     "yixboost": "naslambers.synology.me",
-    "mhacdelivery": "mhacdeliverypaniqui112021-ops.github.io",
     "zenvoki": "darkcherry-27ef3.app.onebit.ng"
   },
   "ns": {

--- a/records.json
+++ b/records.json
@@ -109,7 +109,7 @@
     "whoshub": "frdze.github.io",
     "www": "katorlys.github.io",
     "yixboost": "naslambers.synology.me",
-    "yussf112": "yussf112.github.io",
+    "mhacdelivery": "mhacdeliverypaniqui112021-ops.github.io",
     "zenvoki": "darkcherry-27ef3.app.onebit.ng"
   },
   "ns": {


### PR DESCRIPTION
Please add the following CNAME record:

Subdomain:
mhacdelivery.rweb.site

CNAME target:
mhacdeliverypaniqui112021-ops.github.io

Website:
https://mhacdeliverypaniqui112021-ops.github.io/mhacfooddelivery/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Added the `mhacdelivery` site mapping for `mhacdeliverypaniqui112021-ops.github.io`.
  * Removed the `yussf112` site mapping for `yussf112.github.io`.
  * Site routing now reflects the updated mapping configuration, ensuring the new destination is recognized while the previous destination is no longer associated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->